### PR TITLE
Fix error C4800, Implicit conversion from 'UActorComponent *' to bool.

### DIFF
--- a/Source/RuntimeBlueprints/Nodes/ScriptCommunicationNodes.cpp
+++ b/Source/RuntimeBlueprints/Nodes/ScriptCommunicationNodes.cpp
@@ -21,15 +21,10 @@ UActorHasScript::UActorHasScript()
 void UActorHasScript::Execute(int Index, int FromLoopIndex)
 {
 	AActor* Actor = GetConnectedPinValue(InputPins[1]).GetActorArg();
+	
+	bool res = IsValid(Actor) && IsValid(Actor->GetComponentByClass(URuntimeBpConstructor::StaticClass()));
+	OutputPins[1].Value.Array[0].SetBoolArg(res);
 
-	if (Actor)
-	{
-		OutputPins[1].Value.Array[0].SetBoolArg(IsValid(Actor->GetComponentByClass(URuntimeBpConstructor::StaticClass())));
-	}
-	else
-	{
-		OutputPins[1].Value.Array[0].SetBoolArg(false);
-	}
 	Super::Execute(0, FromLoopIndex);// 0 here is the output pins array index
 }
 

--- a/Source/RuntimeBlueprints/Nodes/ScriptCommunicationNodes.cpp
+++ b/Source/RuntimeBlueprints/Nodes/ScriptCommunicationNodes.cpp
@@ -24,7 +24,7 @@ void UActorHasScript::Execute(int Index, int FromLoopIndex)
 
 	if (Actor)
 	{
-		OutputPins[1].Value.Array[0].SetBoolArg(Actor->GetComponentByClass(URuntimeBpConstructor::StaticClass()));
+		OutputPins[1].Value.Array[0].SetBoolArg(IsValid(Actor->GetComponentByClass(URuntimeBpConstructor::StaticClass())));
 	}
 	else
 	{


### PR DESCRIPTION
To avoid possible information loss, use 'IsValid' for ActorComponent pointer's validity.